### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function set (obj, path, value) {
       obj[path[i]] = value
     else if(null == obj[path[i]])
       obj = (obj[path[i]] = isNonNegativeInteger(path[i+1]) ? [] : {})
-    else
+    else if (!(isPrototypePolluted(path[i])))
       obj = obj[path[i]]
   return value
 }
@@ -89,6 +89,10 @@ function clone (obj) {
   _obj = Array.isArray(obj) ? [] : {}
   for(var k in obj) _obj[k] = clone(obj[k])
   return _obj
+}
+
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
 }
 
 exports.get = get


### PR DESCRIPTION
### :bar_chart: Metadata *

`libnested` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-libnested

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var libnested = require("libnested")
var obj = {}
console.log("Before : " + {}.polluted);
libnested.set(obj, ['__proto__','polluted'], 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i libnested # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104118673-aa9f7c80-5350-11eb-9e7d-245e2c923989.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
